### PR TITLE
Bump Microsoft.AspNetCore.Mvc

### DIFF
--- a/samples/features/json/angularjs/dotnet-tour-of-heroes/dotnet-tour-of-heroes.csproj
+++ b/samples/features/json/angularjs/dotnet-tour-of-heroes/dotnet-tour-of-heroes.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Belgrade.Sql.Client" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />


### PR DESCRIPTION
Bumps Microsoft.AspNetCore.Mvc from 1.0.3 to 1.0.4.

Signed-off-by: dependabot[bot] <support@github.com>